### PR TITLE
Improve performace of MailItemParser

### DIFF
--- a/src/com/difegue/doujinsoft/wc24/MailItemParser.java
+++ b/src/com/difegue/doujinsoft/wc24/MailItemParser.java
@@ -37,6 +37,7 @@ import com.difegue.doujinsoft.templates.Collection;
 
 public class MailItemParser extends WC24Base {
 
+    private final Pattern pattern = Pattern.compile("w([0-9]*)@"+ Pattern.quote(wc24Server));
     private String dataDir;
     private String mailFallbackCode;
 	
@@ -193,7 +194,6 @@ public class MailItemParser extends WC24Base {
     private String getWiiCode(String address) {
 
         // Get wii code by stripping "w" and "@wii.com" from the sender's address
-        Pattern pattern = Pattern.compile("w([0-9]*)@"+ Pattern.quote(wc24Server));
         Matcher matcher = pattern.matcher(address);
         while (matcher.find()) {
             return matcher.group(1);


### PR DESCRIPTION
[Compiling regex is expensive](https://stackoverflow.com/questions/1720191/java-util-regex-importance-of-pattern-compile). The regex can be compiled once and reused for the lifetime of the MailItemParser, instead of recompiling it every time you want to match. 

This could be improved more if the pattern was `static final` but since `wc24Server` is an instance variable and I'm not sure what the repercussions would be if it was made static, I decided against it.

