### PR TITLE
Fix LIKE query for searching games

### DIFF
--- a/src/com/difegue/doujinsoft/utils/TemplateBuilder.java
+++ b/src/com/difegue/doujinsoft/utils/TemplateBuilder.java
@@ -187,8 +187,8 @@ public class TemplateBuilder {
 		PreparedStatement retCount = connection.prepareStatement(queryCount);
 
 		// Those filters go in the LIKE parts of the query
-		String name = isNameSearch ? request.getParameter("name") + "%" : "%";
-		String creator = isCreatorSearch ? request.getParameter("creator") + "%" : "%";
+		String name = isNameSearch ? "%" + request.getParameter("name") + "%" : "%";
+		String creator = isCreatorSearch ? "%" + request.getParameter("creator") + "%" : "%";
 
 		int page = 1;
 		if (request.getParameterMap().containsKey("page") && !request.getParameter("page").isEmpty())


### PR DESCRIPTION
For search queries, DoujinSoft doesn't show results that have a prefix. For example, if I search dog, then a microgame about dog feeding might show up, not a game about hot dogs. It's been bothering me because it makes it harder to search for what I'm looking for. This PR should fix the command.
