### PR TITLE
Reduce latency for music and sync with OS sample rate

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
     "blueimp-file-upload": "^10.32.0",
     "jquery": "^3.6.0",
     "jquery-ui": "^1.12.1",
-    "mio-midi": "^0.5.0",
+    "mio-midi": "^0.6.0",
     "mio-player": "^0.4.0",
-    "timidity": "git://github.com/yeahross0/timidity#9cb57cf"
+    "timidity": "git://github.com/yeahross0/timidity#aa1b2e0"
   },
   "devDependencies": {
     "eslint": "^7.32.0",


### PR DESCRIPTION
Version bump that:

- merges in this change: https://github.com/feross/timidity/issues/14
- reduces the buffer size in timidity so there should be less of delay when the music starts
- adds a silent note to the end of midi files so timidity doesn't cut the music off early