### PR TITLE
Play music using soundfont sf2 file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ DoujinSoft.iml
 node_modules
 package-lock.json
 WebContent/soundfont/libtimidity.wasm
+WebContent/soundfont/WarioWare_D.I.Y._Soundfont.sf2
 WebContent/js/vendor/*
 WebContent/css/vendor/*
 .settings/*

--- a/WebContent/WEB-INF/templates/base.html
+++ b/WebContent/WEB-INF/templates/base.html
@@ -35,7 +35,7 @@
   <script src='js/vendor/mio-player.js'></script>
   <script src='js/vendor/mio-midi.js'></script>
   <script src="js/jquery.simplePagination.js"></script>
-  <script src="js/init.js?v3.6"></script>
+  <script src="js/init.js?v3.7"></script>
 
   <script data-goatcounter="https://ohmy.tvc-16.science/count" async src="//ohmy.tvc-16.science/count.js"></script>
 
@@ -68,7 +68,7 @@
 <body>
 
   <script type="module">
-    import init, { play_sound, stop_sound } from "./js/vendor/synth_wasm/synth_wasm.js";
+    import init, { play_sound, stop_sound } from "./js/vendor/synth-wasm/synth_wasm.js";
 
     init().then(() => {
       window.synth_wasm = {

--- a/WebContent/WEB-INF/templates/base.html
+++ b/WebContent/WEB-INF/templates/base.html
@@ -67,6 +67,17 @@
 
 <body>
 
+  <script type="module">
+    import init, { play_sound, stop_sound } from "./js/vendor/synth_wasm/synth_wasm.js";
+
+    init().then(() => {
+      window.synth_wasm = {
+        play_sound,
+        stop_sound,
+      }
+    });
+  </script>
+
   <div class="navbar-fixed">
     <nav class="{% block color %}indigo{% endblock %} darken-3" role="navigation">
       <div class="nav-wrapper container">

--- a/WebContent/WEB-INF/templates/modalPlayer.html
+++ b/WebContent/WEB-INF/templates/modalPlayer.html
@@ -364,24 +364,6 @@
         mioPlayer.withdrawTouchFromScreen();
     }
 
-    // _fetch function taken from timidity by Feross Aboukhadijeh
-    // https://github.com/feross/timidity
-    async function _fetch(url) {
-        const opts = {
-            mode: 'cors',
-            credentials: 'same-origin'
-        }
-        const response = await window.fetch(url, opts)
-        if (response.status !== 200) {
-            popToast(`Could not load ${url}`);
-            throw new Error(`Could not load ${url}`)
-        };
-
-        const arrayBuffer = await response.arrayBuffer()
-        const buf = new Uint8Array(arrayBuffer)
-        return buf
-    }
-
     async function buildMidiData(mioData) {
         let loopTimes;
 
@@ -447,9 +429,15 @@
 
         mioPlayer.musicPlayer = {
             playMusic: () => {
-                window.synth_wasm.play_sound(sf2Data, midiData)
+                if (window.synth_wasm) {
+                    window.synth_wasm.play_sound(sf2Data, midiData)
+                }
             },
-            stopMusic: () => window.synth_wasm.stop_sound(),
+            stopMusic: () => {
+                if (window.synth_wasm) {
+                    window.synth_wasm.stop_sound()
+                }
+            },
         };
 
         let fontBitmap = new Image();
@@ -474,7 +462,9 @@
         }
 
         // Single game replay
-        window.synth_wasm.play_sound(sf2Data, midiData)
+        if (window.synth_wasm) {
+            window.synth_wasm.play_sound(sf2Data, midiData);
+        }
         mioPlayer.loadAndStart(mioData);
     }
 

--- a/WebContent/WEB-INF/templates/modalPlayer.html
+++ b/WebContent/WEB-INF/templates/modalPlayer.html
@@ -65,7 +65,6 @@
     var score;
     var isPlayingCollection = false;
     var currentCollectionIteration = 0;
-    var hasTrackEnded = false;
     var lostLastGame = false;
     var isBossGame = false;
     var tempHash = null;
@@ -80,11 +79,15 @@
     var sounds = [];
     var playerSounds = [];
 
+    var sf2Data = null;
+    (async () => {
+    sf2Data = await _fetch('./soundfont/WarioWare_D.I.Y._Soundfont.sf2')
+    })();
+
     $('#game-modal').modal({
         dismissible: true,
         onCloseEnd: function () {
             context.clearRect(0, 0, canvas.width, canvas.height);
-            player.pause();
             mioPlayer.stop();
 
             // Stop all sounds
@@ -389,9 +392,7 @@
         } else {
             loopTimes = 11; // boss length (11 is a completely arbitrary number)
         }
-        midiData = window.buildMidiFile(mioData, loopTimes);
-
-        await player.load(midiData);
+        midiData = window.mio_midi.buildMidiFile(mioData, loopTimes);
     }
 
     function playGame(mioData) {
@@ -444,17 +445,11 @@
         canvas.addEventListener('touchstart', handleTouchStart, false);
         document.addEventListener('touchend', handleTouchEnd, false);
 
-        player.on('ended', () => { hasTrackEnded = true; });
-
         mioPlayer.musicPlayer = {
             playMusic: () => {
-                player.pause();
-                player.seek(0);
-                player.play();
-                hasTrackEnded = false;
+                window.synth_wasm.play_sound(sf2Data, midiData)
             },
-            pauseMusic: () => player.pause(),
-            hasTrackEnded: () => hasTrackEnded,
+            stopMusic: () => window.synth_wasm.stop_sound(),
         };
 
         let fontBitmap = new Image();
@@ -479,8 +474,7 @@
         }
 
         // Single game replay
-        player.pause();
-        player.load(midiData);
+        window.synth_wasm.play_sound(sf2Data, midiData)
         mioPlayer.loadAndStart(mioData);
     }
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "jquery": "^3.6.0",
     "jquery-ui": "^1.12.1",
     "mio-player": "1.0.0-beta.1",
-    "mio-midi": "1.0.0-beta.2",
+    "mio-midi": "1.0.0-beta.4",
+    "synth-wasm": "0.1.0",
     "timidity": "git://github.com/yeahross0/timidity#aa1b2e0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "jquery": "^3.6.0",
     "jquery-ui": "^1.12.1",
     "mio-player": "1.0.0-beta.1",
-    "mio-midi": "1.0.0-beta.1",
+    "mio-midi": "1.0.0-beta.2",
     "timidity": "git://github.com/yeahross0/timidity#aa1b2e0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "jquery": "^3.6.0",
     "jquery-ui": "^1.12.1",
     "mio-player": "1.0.0-beta.1",
-    "mio-midi": "1.0.0-beta.7",
+    "mio-midi": "1.0.0-beta.8",
     "synth-wasm": "0.1.0",
     "timidity": "git://github.com/yeahross0/timidity#aa1b2e0"
   },

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "blueimp-file-upload": "^10.32.0",
     "jquery": "^3.6.0",
     "jquery-ui": "^1.12.1",
-    "mio-player": "^0.6.2",
-    "mio-midi": "^0.7.0",
+    "mio-player": "1.0.0-beta.1",
+    "mio-midi": "1.0.0-beta.1",
     "timidity": "git://github.com/yeahross0/timidity#aa1b2e0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "jquery": "^3.6.0",
     "jquery-ui": "^1.12.1",
     "mio-player": "1.0.0-beta.1",
-    "mio-midi": "1.0.0-beta.4",
+    "mio-midi": "1.0.0-beta.7",
     "synth-wasm": "0.1.0",
     "timidity": "git://github.com/yeahross0/timidity#aa1b2e0"
   },

--- a/tools/install-front.sh
+++ b/tools/install-front.sh
@@ -22,4 +22,4 @@ cp WebContent/soundfont/freepats.cfg node_modules/timidity/freepats.cfg
 
 browserify -r timidity -o WebContent/js/vendor/timidity.js -s timidity
 browserify -r mio-player -o WebContent/js/vendor/mio-player.js -s mio
-browserify -r mio-midi -o WebContent/js/vendor/mio-midi.js -s buildMidiFile
+browserify -r mio-midi -o WebContent/js/vendor/mio-midi.js -s mio_midi

--- a/tools/install-front.sh
+++ b/tools/install-front.sh
@@ -10,6 +10,7 @@ cp node_modules/jquery-ui/dist/jquery-ui.min.js WebContent/js/vendor
 cp node_modules/blueimp-file-upload/js/jquery.fileupload.js WebContent/js/vendor
 cp node_modules/@materializecss/materialize/dist/js/materialize.min.js WebContent/js/vendor
 cp node_modules/timidity/libtimidity.wasm WebContent/soundfont
+cp node_modules/synth-wasm/ WebContent/js/vendor
 
 cp node_modules/@materializecss/materialize/dist/css/materialize.min.css WebContent/css/vendor
 cp node_modules/blueimp-file-upload/css/jquery.fileupload.css WebContent/css/vendor

--- a/tools/install-front.sh
+++ b/tools/install-front.sh
@@ -10,7 +10,7 @@ cp node_modules/jquery-ui/dist/jquery-ui.min.js WebContent/js/vendor
 cp node_modules/blueimp-file-upload/js/jquery.fileupload.js WebContent/js/vendor
 cp node_modules/@materializecss/materialize/dist/js/materialize.min.js WebContent/js/vendor
 cp node_modules/timidity/libtimidity.wasm WebContent/soundfont
-cp node_modules/synth-wasm/ WebContent/js/vendor
+cp -r node_modules/synth-wasm/ WebContent/js/vendor
 
 cp node_modules/@materializecss/materialize/dist/css/materialize.min.css WebContent/css/vendor
 cp node_modules/blueimp-file-upload/css/jquery.fileupload.css WebContent/css/vendor


### PR DESCRIPTION
Plays music using a different library which can handle .sf2 files instead of .pat files. This should help the instruments sound better as the soundfont doesn't have to undergo another conversion process.

Also the new audio player won't use the deprecated ScriptProcessorNode API and may (or may not) have fewer issues keeping the music in sync with the game.

And there's a new buildRecordMidiFile method in mio-midi. This can create the midi data for DIY records. So the 2 different types of mio files should be able to use mio-midi and the new synth_wasm library.

Sf2 not included

Thanks to vincells for testing