### PR TITLE
Update versions + swing

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "blueimp-file-upload": "^10.32.0",
     "jquery": "^3.6.0",
     "jquery-ui": "^1.12.1",
-    "mio-player": "1.0.0-beta.1",
-    "mio-midi": "1.0.0-beta.8",
+    "mio-player": "1.0.0",
+    "mio-midi": "1.0.0-beta.9",
     "synth-wasm": "0.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Changes the offset for swing notes

Published mio-player as 1.0.0 since it's been used a while but was still at version zero